### PR TITLE
Revised Forsaken Traits

### DIFF
--- a/Heroes Handbook, Main File
+++ b/Heroes Handbook, Main File
@@ -1148,9 +1148,9 @@ Your forsaken character has certain traits deriving from humans, as well as fors
 
 ***Darkvision.*** Forsakens can see normal in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can't discern color in darkness, only shades of gray.
 
-***Cannibalism.*** You can spend a minute cannibalizing the corpse of a humanoid or beast that has been dead for less than hour. When done, you can expend hit dies as if you had finished a short rest.
+***Cannibalism.*** Using a minute, you can cannibalize the corpse of a humanoid or beast that has been dead for less than 1 hour. When done, you regain a number of hit point sequal to your level + your Constitution modifier. Once you use this trait, you can't use it again until you finish a short rest.
 
-***Undead Nature.*** You have two creature types: humanoid and undead. You can be affected by a game effect if it works on either of your creature types. In addition, you gain the following benefits:
+***Undead.*** You have two creature types: humanoid and undead. You can be affected by a game effect if it works on either of your creature types. In addition, you gain the following benefits:
 <div style='margin-top:-7px;'></div>
 
  - You don't require food, water, or sleep, although you still require rest to reduce exhaustion and still benefit from finishing short and long rests.

--- a/Heroes Handbook, Main File
+++ b/Heroes Handbook, Main File
@@ -1123,6 +1123,8 @@ Forsaken, unsurprisingly, look like dead people. Their skin is gray and rotting,
 
 \pagebreakNum
 
+<div style='margin-top:320px;'></div>
+
 ### Affiliation
 Though the Forsaken do not trust anyone and no one trusts them, they are members of the Horde and, for now, do their best to help their allies and placate their ambassadors. Forsaken have even less love for the Alliance, particularly because they clash constantly with the human organization called the Scarlet Crusade.
 
@@ -1130,8 +1132,6 @@ The only other Horde faction they have a semblance of trust with is Silvermoon C
 
 ### Names
 Most forsaken keep the human or blood elven name they had when they were alive. If a forsaken cannot remember their name, or simply wishes to change it, they make up a suitable name or read one from a headstone. Some invent surnames that imply their desire to eradicate the Scourge or about their undead nature.
-
-\columnbreak
 
 ### Forsaken Traits
 Your forsaken character has certain traits deriving from humans, as well as forsaken traits.
@@ -1148,13 +1148,20 @@ Your forsaken character has certain traits deriving from humans, as well as fors
 
 ***Darkvision.*** Forsakens can see normal in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can't discern color in darkness, only shades of gray.
 
-***Cannibalism.*** Using a minute, you can cannibalize the corpse of a humanoid or beast that has been dead for less than 1 hour. When done, you regain a number of hit point sequal to your level + your Constitution modifier. Once you use this trait, you can't use it again until you finish a short rest.
+***Cannibalism.*** Using 1 minute, you can cannibalize the corpse of a humanoid that has been dead for less than 1 hour. When done, you regain a number of hit point sequal to your level + your Constitution modifier. Once you use this trait, you can't use it again until you finish a short rest.
+
+\columnbreak
+
+<div style='margin-top:350px;'></div>
+
+&nbsp;&nbsp;&nbsp; ***Touch of the Grave.*** Forsaken don't need to sleep. Instead, they enter a semiconscious state of the afterlife for 4 hours a day. After resting in this way, you gain the same benefit that a human does from 8 hours of sleep.
 
 ***Undead.*** You have two creature types: humanoid and undead. You can be affected by a game effect if it works on either of your creature types. In addition, you gain the following benefits:
-<div style='margin-top:-7px;'></div>
+<div style='margin-top:-10px;'></div>
 
- - You don't require food, water, or sleep, although you still require rest to reduce exhaustion and still benefit from finishing short and long rests.
+ - You don't require food, or water.
  - You have resistance to poison damage, and advantage on saving throws against being poisoned.
+<div style='margin-top:-7px;'></div>
 
 ***Will of the Forsaken.*** You have advantage on saving throws against being charmed, effects that turn undead, and magic can't put you to sleep.
 
@@ -1179,9 +1186,8 @@ As a forsaken human, you were once a proud human of Lordaeron. A human society a
 ***Human Resolve.*** When you make an attack roll, an ability check, or a saving throw, you can do so with advantage. Once you use this ability, you can't use it again until you finish a short or long rest.
 
 <div class='footnote'>PART 1 | RACES</div>
-<img src='https://www.gmbinder.com/images/M8d875w.jpg' style='position:absolute; top:350px; right:260px; width:730px' />
-<img src='https://www.gmbinder.com/images/ohZghLL.png' style='position:absolute; top:0px; right:-90px; width:900px' />
-<img src='https://www.gmbinder.com/images/6aELefD.png' style='position:absolute; top:-470px; right:0px; width:900px;transform:rotate(5deg)' />
+<img src='https://www.gmbinder.com/images/M8d875w.jpg' style='position:absolute; top:-400px; right:0px; width:800px' />
+<img src='https://i.imgur.com/Mgi0q18.png' style='position:absolute; top:30px; right:0px; width:900px' />
 
 \pagebreakNum
 

--- a/Heroes Handbook, Main File
+++ b/Heroes Handbook, Main File
@@ -1156,7 +1156,7 @@ Your forsaken character has certain traits deriving from humans, as well as fors
  - You don't require food, water, or sleep, although you still require rest to reduce exhaustion and still benefit from finishing short and long rests.
  - You have resistance to poison damage, and advantage on saving throws against being poisoned.
 
-***Will of the Forsaken.*** You have advantage on saving throws against being charmed, and effects that turn undead, and magic can't put you to sleep.
+***Will of the Forsaken.*** You have advantage on saving throws against being charmed, effects that turn undead, and magic can't put you to sleep.
 
 ***Languages.*** You can speak, read, and write Common and Gutterspeak. Gutterspeak is a simple form of common that mixes in Dwarven and Thalassian slurs. 
 

--- a/Heroes Handbook, Main File
+++ b/Heroes Handbook, Main File
@@ -1144,39 +1144,39 @@ Your forsaken character has certain traits deriving from humans, as well as fors
 
 ***Size.*** Forsaken size reflects that of their living counter-parts. Many getting more hunched over with the decades. Your size is Medium.
 
-***Speed.*** Your base walking speed is 30 feet. 
-
-***Cannibalism.*** You can spend a minute cannibalizing the corpse of a humanoid or beast that has been dead for less than hour. When done, you can expend hit dies as if you had finished a short rest.
+***Speed.*** Your base walking speed is 30 feet.
 
 ***Darkvision.*** Forsakens can see normal in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can't discern color in darkness, only shades of gray.
 
-***Undead.*** Your creature type is undead instead of human-oid. Being undead gives you the following benefits:
- - You have two creature types: humanoid and undead. You can be affected by a game effect if it works on either of your creature types.
- - You have advantage on saving throws against effects that turn undead.
- - You don't require food, water or sleep, although you still require rest to reduce exhaustion and still benefit from finishing short and long rests.
+***Cannibalism.*** You can spend a minute cannibalizing the corpse of a humanoid or beast that has been dead for less than hour. When done, you can expend hit dies as if you had finished a short rest.
+
+***Undead Nature.*** You have two creature types: humanoid and undead. You can be affected by a game effect if it works on either of your creature types. In addition, you gain the following benefits:
+<div style='margin-top:-7px;'></div>
+
+ - You don't require food, water, or sleep, although you still require rest to reduce exhaustion and still benefit from finishing short and long rests.
  - You have resistance to poison damage, and advantage on saving throws against being poisoned.
 
-***Will of the Forsaken.*** You have advantage on saving throws against being charmed or frightened, and magic can't put you to sleep.
+***Will of the Forsaken.*** You have advantage on saving throws against being charmed, and effects that turn undead, and magic can't put you to sleep.
 
-***Languages.*** You can speak, read, and write Common and Gutterspeak. Gutterspeak is a simple form of common mixed with dwarven and thalassian, originally the language of underground rogues, it has since been adapted as the forsakens official language.
+***Languages.*** You can speak, read, and write Common and Gutterspeak. Gutterspeak is a simple form of common that mixes in Dwarven and Thalassian slurs. 
 
 ***Subrace.*** Two kinds of forsaken exist on Azeroth, elves and humans. Choose one of these subraces.
 
 #### Forsaken Elf
-As a forsaken elf, you were once a high elf off quel'thalas, overtaken by the scourge. Now usually serving as high and powerful members within Sylvanas' rule.
+As a forsaken elf, you were once a high elf off Quel'thalas, overtaken by the scourge. Now usually serving as high and powerful members within Sylvanas' rule.
 
 ***Ability Score Increase.*** Your Intelligence increases by 1.
 
-***Thalassian Knowledge.*** You gain proficiency in the Arcana skill.
+***Quel'dorei Legacy.*** You can cast *magic missiles* and *shield* with this trait, using Intelligence as your spellcasting ability for them. Once you cast either spell, you can't cast it again with this trait until you finish a short or long rest.
 
 ***Languages.*** You can speak, read, and write Thalassian.
 
 #### Forsaken Human
-As a forsaken human, you were once a proud human of lordaeron. A human society at the top of the eastern kingdoms, that the scourge all but leveled with the ground in its passing. Now, broken from the scourges will, you serve under Queen Sylvanas' rule.
+As a forsaken human, you were once a proud human of Lordaeron. A human society at the top of the Eastern Kingdoms, that the scourge all but leveled with the ground in its passing. Now, broken from the scourges will, you serve under Queen Sylvanas' rule.
 
-***Ability Score Increase.*** One ability scores of your choice increase by 1.
+***Ability Score Increase.*** One other ability scores of your choice increases by 1.
 
-***Skills.*** You gain proficiency in one skill of your choice.
+***Human Resolve.*** When you make an attack roll, an ability check, or a saving throw, you can do so with advantage. Once you use this ability, you can't use it again until you finish a short or long rest.
 
 <div class='footnote'>PART 1 | RACES</div>
 <img src='https://www.gmbinder.com/images/M8d875w.jpg' style='position:absolute; top:350px; right:260px; width:730px' />


### PR DESCRIPTION
Forsakens are difficult to balance because of their undead nature, so Forsaken Elfs got a score of 29, and Humans at 28 on the Detect Balance scale.