### PR TITLE
Forsaken Formatting Error Fix

### DIFF
--- a/Heroes Handbook, Main File
+++ b/Heroes Handbook, Main File
@@ -1163,7 +1163,7 @@ Your forsaken character has certain traits deriving from humans, as well as fors
  - You have resistance to poison damage, and advantage on saving throws against being poisoned.
 <div style='margin-top:-7px;'></div>
 
-***Will of the Forsaken.*** You have advantage on saving throws against being charmed, effects that turn undead, and magic can't put you to sleep.
+&nbsp;&nbsp;&nbsp; ***Will of the Forsaken.*** You have advantage on saving throws against being charmed, effects that turn undead, and magic can't put you to sleep.
 
 ***Languages.*** You can speak, read, and write Common and Gutterspeak. Gutterspeak is a simple form of common that mixes in Dwarven and Thalassian slurs. 
 


### PR DESCRIPTION
A tiny formatting error with the forsakens "Will of the Forsaken" trait, not being in line with the rest of the traits.