### PR TITLE
writing: fix Explorers' League typo

### DIFF
--- a/Manual of Monsters, Main File
+++ b/Manual of Monsters, Main File
@@ -5551,7 +5551,7 @@ ___
 *Among the troggs, the biggest and strongest becomes chieftain. All through their displays of power, intimidation, and sometimes what might as well be considered psychological warfare.*
 <div style="text-align:Right">
 
-*— The Explorer's League Treatise on Troggs* &nbsp;</div>
+*— The Explorers' League's Treatise on Troggs* &nbsp;</div>
 <div style='margin-top:-5px'></div>
 
 Troggs are savage creatures, powerfully built with long, muscular arms and muscles that appear carved from stone. They grow thick, coarse beards in colours resembling chalk or granite, and it is not rare to see minerals outright growing on their flesh. Their slouched posture and burly proportions have many characterizing them as apelike troglodytes.


### PR DESCRIPTION
It should've been *Explorers' League*, not Explorer's League.