### PR TITLE
format: wind serpents

### DIFF
--- a/Manual of Monsters, Main File.txt
+++ b/Manual of Monsters, Main File.txt
@@ -6326,7 +6326,31 @@ ___
 
 \pagebreakNum
 
+<div style='margin-top:160px;'></div>
+
 ## Wind Serpents
+Many adventures have seen these serpentine creatures roaming the vast deserted regions of the world, slithering across its sandy surfaces or using their powerful wings to keep them drifting above its surface. The predatory snakes pays little attention to wandering adventures, as their eyes are set on a difference price, but once provoked they become a frightening enemy to fight in large numbers.
+
+A wind serpent combines the body and head of a snake with the leathery wings of a drake, and the feathers of a brightly colored bird. Its poisonous fangs and innate ability to spew with elemental forces makes it a formidable foe.
+
+***Spiritual Creatures.*** The winged serpents are often seen by lesser races as spirits of the sky and have become revered by tribal races such as quilboars. It is also believed that the serpents carry a connection towards the loa Hakkar the Soulflayer, granting them to name *children of hakkar* by certain individuals, and earning them a favorable place of worship by devoted individuals.
+
+***Unseen Hunters.*** Wind serpents makes for formidable hunters. They are a predator that will ambush their prey if possible to gain the moments advantage needed for a kill. They crawl among tree branches, stalk within fissures in the earth, or fly silently out from a dark nook towards their desired prey. They attack with lightning speed, swiftly poisoning their quarry.
+
+***Adapted Species.*** These serpentine creatures can be found in the far reaches of the world. They nest in hard-to-reach places where they can retire in safety. Many have migrated to temperate regions of the world, but some have ventured to far off places. Different subspecies of wind serpents very drastically from one another. They have adapted to their surrounding climate and changes to better survive in it. Some even becoming magical beings capable of spewing crackling lightning or freezing mist.
+
+Perceptive adventures are able to use the colorful scales of a wind serpent as a warning before engaging in an open fight. Their colors display nuances of the element force kept within, if any.
+
+> ##### Variant: Adapted Wind Serpents
+> Wind serpents are found throughout Azeroth and have adapted differently to their climate.
+>
+> ***Poison Breath.*** You can change a wind serpent's breath attack to deal either acid, cold, or lightning damage. If changed to acid or lightning, the breath attack changes from a *cone* to a 5-foot wide *line* with a length equal to twice the cone's size, and the saving throw for the attack changes to Dexterity.
+>
+> ***Venomous Bite and Toxic Spit.*** You can change the damage type of these actions to acid, cold, or lightning instead of poison damage.
+
+\columnbreak
+
+<div style='margin-top:390px;'></div>
 
 ___
 > ## Wind Serpent
@@ -6334,7 +6358,7 @@ ___
 > ___
 > - **Armor Class** 15 (natural armor)
 > - **Hit Points** 22 (5d8)
-> - **Speed** 20 ft., fly 40 ft.
+> - **Speed** 20 ft., climb 20 ft., fly 40 ft.
 >___
 >|STR|DEX|CON|INT|WIS|CHA|
 >|:---:|:---:|:---:|:---:|:---:|:---:|
@@ -6353,16 +6377,22 @@ ___
 >
 > ***Constrict.*** *Melee Weapon Attack:* +4 to hit, reach 10 ft., one Medium or smaller creature. *Hit:* 9 (2d6 + 2) bludgeoning damage, and the target is grappled (escape DC 12). Until this grapple ends, the target is restrained, and the wind serpent can't constrict another target.
 >
-> ***Lightning Breath (Recharges after a Short or Long Rest).*** The serpent exhales lightning in a 20-foot line that is 5 feet wide. Each creature in that line must make a DC 12 Dexterity saving throw, taking 11 (2d10) lightning damage on a failed save, or half as much damage on a successful one.
+> ***Poison Breath (Recharges after a Short or Long Rest).*** The wind serpent exhales poisonous gas in a 10-foot cone. Each creature in that area must make a DC 12 Constitution saving throw, taking 11 (2d10) poison damage on a failed save, or half as much damage on a successful one.
 
-\columnbreak
+<div class="pageLetter">W</div>
+<div class='footnote'>WIND SERPENTS </div>
+<img src='https://www.gmbinder.com/images/Vm7cCm7.jpg' style='position:absolute; top:0px; right:-200px; width:900px;transform:scalex(-1)' />
+<img src='https://www.gmbinder.com/images/f9sluCp.png' style='position:absolute; top:0px; right:-80px; width:900px;transform:scalex(-1)' />
+
+\pagebreakNum
+
 ___
 > ## Wind Serpent Stinglash
 >*Medium beast, neutral*
 > ___
 > - **Armor Class** 15 (natural armor)
 > - **Hit Points** 33 (6d8 + 5)
-> - **Speed** 20 ft., fly 40 ft.
+> - **Speed** 20 ft., climb 20 ft., fly 40 ft.
 >___
 >|STR|DEX|CON|INT|WIS|CHA|
 >|:---:|:---:|:---:|:---:|:---:|:---:|
@@ -6387,18 +6417,7 @@ ___
 >
 > ***Toxic Spit.*** *Ranged Weapon Attack:* +5 to hit, range 15/30 ft., one creature. *Hit:* The target must make a DC 13 Constitution saving throw, taking 21 (6d6) poison damage on a failed save, or half as much damage on a successful one.
 
-> ##### Variant: Wind Serpents of Azeroth
-> Wind serpents are found throughout Azeroth and have adapted differently to their climate.
->
-> ***Lightning Breath.*** You can change a wind serpent's breath attack to deal either acid or cold damage, changing the breath attack from a *line* to a *cone* of size equal to half the line's length.
->
-> ***Venomous Bite and Toxic Spit.*** You can change the damage type of these actions to acid, cold, or lightning instead of poison damage.
-
-<div class="pageLetter">W</div>
-<div class='footnote'>WIND SERPENTS </div>
-<img src='https://www.gmbinder.com/images/RVaHjr8.png' style='position:absolute; top:0px; right:0px; width:900px' />
-
-\pagebreakNum
+\columnbreak
 
 ___
 > ## Wind Serpent Dreadfang
@@ -6406,7 +6425,7 @@ ___
 > ___
 > - **Armor Class** 17 (natural armor)
 > - **Hit Points** 60 (11d8 + 11)
-> - **Speed** 30 ft., fly 60 ft.
+> - **Speed** 30 ft., climb 30 ft., fly 60 ft.
 >___
 >|STR|DEX|CON|INT|WIS|CHA|
 >|:---:|:---:|:---:|:---:|:---:|:---:|
@@ -6429,11 +6448,12 @@ ___
 >
 > ***Frightful Screech.*** Each creature within 60 feet of the serpent that can hear it must succeed on a DC 12 Wisdom saving throw or be frightened for 1 minute. A frightened target can repeat the saving throw at the end of each of its turns, ending the frightened condition on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to this serpent's Frightful Screech for the next 24 hours. 
 >
-> ***Lightning Breath (Recharge 5-6).*** The serpent exhales lightning in a 40-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 27 (5d10) lightning damage on a failed save, or half as much damage on a success.
+> ***Poison Breath (Recharge 5-6).*** The serpent exhales poisonous gas in a 20-foot cone. Each creature in that area must make a DC 14 Constitution saving throw, taking 27 (5d10) poison damage on a failed save, or half as much damage on a successful one.
 
 <div class="pageLetter">W</div>
 <div class='footnote'>WIND SERPENTS </div>
-<img src='https://www.gmbinder.com/images/RVaHjr8.png' style='position:absolute; top:0px; right:0px; width:900px' />
+<img src='https://www.gmbinder.com/images/QC98AHW.jpg' style='position:absolute; top:450px; right:0px; width:900px' />
+<img src='https://www.gmbinder.com/images/ykqNB77.png' style='position:absolute; top:0px; right:0px; width:900px' />
 
 \pagebreakNum
 


### PR DESCRIPTION
Formatted the wind serpents, and changed the base damage type for their breath attacks to be poison rather than lightning so that there was some semblance between the three wind serpent monsters. Felt weird that one was poison based whilst the other two were lightning based.