### PR TITLE
style: push corner page tears further to the edge

### DIFF
--- a/Manual of Monsters, Main File.txt
+++ b/Manual of Monsters, Main File.txt
@@ -123,7 +123,7 @@
     background-image: url(https://gmbinder.com/images/lLWeevR.png), url('https://gmbinder.com/images/YWardeu.png');
     background-size: 120px 120px, 816px 55px;
     background-repeat: no-repeat, no-repeat;
-    background-position: bottom right, bottom;
+    background-position: bottom right -10px, bottom;
   }
 
   /* Hacked reverse of the Monster Manual page tear for alternating pages */
@@ -133,24 +133,34 @@
     background-image: url(https://gmbinder.com/images/lLWeevR.png), url('https://gmbinder.com/images/YWardeu.png');
     background-size: 120px 120px, 816px 55px;
     background-repeat: no-repeat, no-repeat;
-    background-position: bottom right, bottom;
+    background-position: bottom right -10px, bottom;
     -webkit-transform: scaleX(-1);
     transform: scaleX(-1);
+  }
+
+  /* The page number position */
+  .phb .pageNumber {
+    right: 0px;
+  }
+
+  /* The page number position for alternating pages */
+  .phb:nth-child(even) .pageNumber {
+    left: 0px;
   }
 
   /* The letter in the Monster Manual page tear */
   .pageLetter {
     position: absolute;
-    right: 25px;
+    right: 15px;
     bottom: 87.5px;
-    color: #673e1c;
+    color: #905727;
     z-index: 1000;
     font-size: 135%;
   }
 
   /* Reversed for alternating pages */
   .phb:nth-child(even) .pageLetter {
-      left: 25px;
+      left: 15px;
   }
 
 


### PR DESCRIPTION
The Monster Manual page tears in the corners were too far in toward the content, since we're using an A4 page format (as opposed to a US letter format).

This solves that by pushing the page tear with the page number, and the corner arrow with the category number, further out to the side. 